### PR TITLE
fixup! FIX: ファイルが選択されていないときもボタンが押せない問題を修正

### DIFF
--- a/app/src/main/java/com/view/MainActivity.java
+++ b/app/src/main/java/com/view/MainActivity.java
@@ -101,8 +101,7 @@ public class MainActivity extends AppCompatActivity {
             fileSelect.changeFile(getUri, this);
             Button buttonStartEval = findViewById(R.id.button_start);
             buttonStartEval.setEnabled(true); // trueにしてボタンを押せるように
-            buttonStartEval.setBackgroundColor(Color.rgb(199, 206, 243)); // 色の変更(これは灰色)
-
+            buttonStartEval.setBackgroundColor(getResources().getColor(R.color.purple_500)); // 色の変更(これは灰色)
             String fileSizeString;
             long fileSizeValue = fileSelect.getFileSize();
             if (fileSizeValue <= 1000)

--- a/app/src/main/java/com/view/MainActivity.java
+++ b/app/src/main/java/com/view/MainActivity.java
@@ -101,7 +101,7 @@ public class MainActivity extends AppCompatActivity {
             fileSelect.changeFile(getUri, this);
             Button buttonStartEval = findViewById(R.id.button_start);
             buttonStartEval.setEnabled(true); // trueにしてボタンを押せるように
-            buttonStartEval.setBackgroundColor(getResources().getColor(R.color.purple_500)); // 色の変更(これは灰色)
+            buttonStartEval.setBackgroundColor(getResources().getColor(R.color.purple_500)); // 色の変更
             String fileSizeString;
             long fileSizeValue = fileSelect.getFileSize();
             if (fileSizeValue <= 1000)


### PR DESCRIPTION
・ボタンの色が灰色のままだったため、ほかボタンと同様の紫色になるよう変更